### PR TITLE
Add existing remote file pass through

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ activate :sync do |sync|
   sync.fog_region = 'bucket-region-name' # The region your storage bucket is in
   sync.aws_access_key_id = 'super' # Your Amazon S3 access key
   sync.aws_secret_access_key = 'secret' # Your Amazon S3 access secret
+  sync.existing_remote_files = 'keep' # What to do with your existing remote files? (keep or delete)
   # sync.after_build = true # Run sync after build
-  # sync.existing_remote_files = 'keep' # What to do with your existing remote files? (keep or delete)
 end
 ```
 
@@ -35,9 +35,9 @@ activate :sync do |sync|
   sync.fog_region = 'bucket-region-name' # The region your storage bucket is in
   sync.rackspace_username = 'karlfreeman' # Your Rackspace username
   sync.rackspace_api_key = 'secret' # Your Rackspace API Key
+  sync.existing_remote_files = 'keep' # What to do with your existing remote files? (keep or delete)
   # sync.rackspace_auth_url = 'domain' # Your Rackspace auth URL
   # sync.after_build = true # Run sync after build
-  # sync.existing_remote_files = 'keep' # What to do with your existing remote files? (keep or delete)
 end
 ```
 
@@ -51,8 +51,8 @@ activate :sync do |sync|
   sync.fog_region = 'bucket-region-name' # The region your storage bucket is in
   sync.google_storage_access_key_id = 'super' # Your Google Storage access key
   sync.google_storage_secret_access_key = 'secret' # Your Google Storage access secret
+  sync.existing_remote_files = 'keep' # What to do with your existing remote files? (keep or delete)
   # sync.after_build = true # Run sync after build
-  # sync.existing_remote_files = 'keep' # What to do with your existing remote files? (keep or delete)
 end
 ```
 

--- a/lib/middleman-sync/extension.rb
+++ b/lib/middleman-sync/extension.rb
@@ -43,7 +43,7 @@ module Middleman
             config.rackspace_auth_url = options.rackspace_auth_url
             config.google_storage_secret_access_key = options.google_storage_secret_access_key
             config.google_storage_access_key_id = options.google_storage_access_key_id
-            config.existing_remote_files = options.existing_remote_files
+            config.existing_remote_files = options.existing_remote_files if options.existing_remote_files
           end
 
           after_build do |builder|

--- a/lib/middleman-sync/extension.rb
+++ b/lib/middleman-sync/extension.rb
@@ -43,6 +43,7 @@ module Middleman
             config.rackspace_auth_url = options.rackspace_auth_url
             config.google_storage_secret_access_key = options.google_storage_secret_access_key
             config.google_storage_access_key_id = options.google_storage_access_key_id
+            config.existing_remote_files = options.existing_remote_files
           end
 
           after_build do |builder|


### PR DESCRIPTION
These two commits add support for the asset_sync existing_remote_files configuration passthrough documented in the readme.
