### PR TITLE
Gemspec change to allow middleman 3.1

### DIFF
--- a/middleman-sync.gemspec
+++ b/middleman-sync.gemspec
@@ -19,6 +19,6 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
   
-  s.add_runtime_dependency("middleman-core", ["~> 3.0.0"])
+  s.add_runtime_dependency("middleman-core", [">= 3.0.0"])
   s.add_runtime_dependency("asset_sync", ["~> 0.5.4"])
 end


### PR DESCRIPTION
Instead of pessimistic version locking of ~>3.0.0 I bumped it to >=3.1 so that it will work with the new ruby 2 compatible middleman 3.1
