### PR TITLE
Register after_build hook on registration, not after configuration

### DIFF
--- a/lib/middleman-sync/extension.rb
+++ b/lib/middleman-sync/extension.rb
@@ -52,10 +52,10 @@ module Middleman
             config.log_silently = false
           end
 
-          after_build do |builder|
-            ::AssetSync.sync if options.after_build
-          end
+        end
 
+        app.after_build do |builder|
+          ::AssetSync.sync if options.after_build
         end
 
       end


### PR DESCRIPTION
As discussed here: http://forum.middlemanapp.com/t/order-of-after-build-callbacks/901
It makes sense that all extensions register their after_build hooks immediately when they are activated so the order in which the hooks are executed is the same as the order in which the extensions were activated.
Similar PR here: https://github.com/middleman/middleman-smusher/pull/5
Docs recommend it as well: http://middlemanapp.com/advanced/custom/#toc_9
