### PR TITLE
Update docs to show after_build setting is off by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ activate :sync do |sync|
   sync.aws_secret_access_key = 'secret' # Your Amazon S3 access secret
   sync.existing_remote_files = 'keep' # What to do with your existing remote files? ( keep or delete )
   # sync.gzip_compression = false # Automatically replace files with their equivalent gzip compressed version
-  # sync.after_build = false # Disable sync to run after Middleman build ( defaults to true )
+  # sync.after_build = true # Enable sync to run after Middleman build ( defaults to false )
 end
 ```
 
@@ -39,7 +39,7 @@ activate :sync do |sync|
   sync.existing_remote_files = 'keep' # What to do with your existing remote files? ( keep or delete )
   # sync.gzip_compression = false # Automatically replace files with their equivalent gzip compressed version
   # sync.rackspace_auth_url = 'domain' # Your Rackspace auth URL
-  # sync.after_build = false # Disable sync to run after Middleman build ( defaults to true )
+  # sync.after_build = true # Enable sync to run after Middleman build ( defaults to false )
 end
 ```
 
@@ -55,7 +55,7 @@ activate :sync do |sync|
   sync.google_storage_secret_access_key = 'secret' # Your Google Storage access secret
   sync.existing_remote_files = 'keep' # What to do with your existing remote files? ( keep or delete )
   # sync.gzip_compression = false # Automatically replace files with their equivalent gzip compressed version
-  # sync.after_build = false # Disable sync to run after Middleman build ( defaults to true )
+  # sync.after_build = true # Enable sync to run after Middleman build ( defaults to false )
 end
 ```
 
@@ -64,13 +64,13 @@ end
 Once you've bundled you should be able to run:
 
 ``` ruby 
-# Turn off after_build in your sync config to disable middleman sync running after each build
-middleman build
-```
-
-``` ruby 
 # Manually sync your current build directory
 middleman sync
+```
+
+To automatically sync after build enable it in your config `sync.after_build = true` and run build:
+``` ruby 
+middleman build
 ```
 
 ## Sync to multiple targets
@@ -88,7 +88,7 @@ activate :sync do |sync|
   sync.aws_access_key_id = 'super' # Your Amazon S3 access key
   sync.aws_secret_access_key = 'secret' # Your Amazon S3 access secret
   sync.existing_remote_files = 'keep' # What to do with your existing remote files? (keep or delete)
-  # sync.after_build = false # Disable sync to run after Middleman build ( defaults to true )
+  sync.after_build = true
 end
 ```
 


### PR DESCRIPTION
Thanks for the gem, have a small doc change suggestion:

I believe that the current docs are incorrect in saying that the after build hook is on by default. I don't see it in the code and I think this issue https://github.com/karlfreeman/middleman-sync/issues/6 states that it is off by default.

This would have reduced some confusion I had when getting started.
